### PR TITLE
Add a text field that accepts a Github URL

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,12 @@
 </head>
 <body>
   <h1>5 minute fork</h1>
+  <form id="serveForm">
+    <label>Github url <input type="text" placeholder="github.com/user/repo" id="input" required pattern="(https?:\/\/)?(www\.)?github\.com\/.*" title="github.com/<user>/<repo> or
+github.com/<user>/<repo>/tree/<branch>"></label>
+    <button type="submit">Serve!</button>
+    <div id="error" style="display: none"></div>
+  </form>
   <p>As described on hackernews:</p>
   <blockquote><p>If a github repo has an index.html file and you click on it, github will show you the source instead of the webpage.<br><br>5minfork shows you the webpage so that you can have an idea of what the repo is about.</p></blockquote>
   <h2 id="why">Why?</h2>
@@ -34,6 +40,31 @@
   <h2 id="fork_this">Fork this?</h2>
   <p>If you're interested in the code, have found a bug, want to fix a bug, have written a browser extension (go on - you know you want to) - the code is <a href="http://rem.mit-license.org/">freely</a> available on github: <a href="https://github.com/remy/5minutefork">https://github.com/remy/5minutefork</a></p>
   <p>Enjoy &mdash; <a href="http://twitter.com/rem">@rem</a></p>
+  <script>
+    (function () {
+      var form = document.getElementById("serveForm");
+      var input = document.getElementById("input");
+      var error = document.getElementById("error");
+
+      var GITHUB_URL_RE = new RegExp(input.placeholder);
+
+      form.addEventListener("submit", function (event) {
+        event.preventDefault();
+        var url = input.value;
+
+        // fallback for browsers that don't support the `pattern` attribute or
+        // showing an notification when validation fails
+        if (!GITHUB_URL_RE.test(url)) {
+          error.textContent = "URL must match either " + input.title;
+          error.style.display = "block";
+        } else {
+          // Remove the github url and use the pathname
+          location.pathname = url.replace(GITHUB_URL_RE, "");
+        }
+      }, false)
+    }());
+  </script>
+
 <script>
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-1656750-31']);

--- a/public/style.css
+++ b/public/style.css
@@ -25,7 +25,7 @@ body {
   padding: 60px 0;
 }
 
-p, h1, h2, h3, blockquote, ul {
+p, h1, h2, h3, blockquote, ul, form {
   max-width: 80%;
   margin-left: auto;
   margin-right: auto;
@@ -96,6 +96,30 @@ blockquote p:before {
   line-height:.1em;
   margin-right:.25em;
   vertical-align:-.4em;
+}
+
+form, form input, form button {
+  font-size: 28px;
+}
+
+form input {
+  width: 50%;
+  padding: 4px;
+}
+
+form button {
+  background: #f9f9f9;
+  border: 1px solid #ccc;
+  padding: 4px;
+}
+
+form input:focus:invalid, #error {
+  color: #900;
+}
+
+#error {
+  font-size: 18px;
+  margin-top: 18px;
 }
 
 body {


### PR DESCRIPTION
Makes it easy to visit the site and paste a Github URL, avoiding the need to mess around in the URL bar.

![screen shot 2013-08-06 at 6 38 16 pm](https://f.cloud.github.com/assets/48019/921644/272f4358-ff02-11e2-9ac4-af850ea447d2.png)

With `pattern` validation magic (plus fallback for Safari). Tested in Chrome, FF and Safari on OS X.
