### PR TITLE
Validate repo/branch path, strip off .git extension

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
 <body>
   <h1>5 minute fork</h1>
   <form id="serveForm">
-    <label>Github url <input type="text" placeholder="github.com/user/repo" id="input" required pattern="(?:https?:\/\/)?(?:www\.)?github\.com\/(.*)" title="github.com/<user>/<repo> or
+    <label>Github url <input type="text" placeholder="github.com/user/repo" id="input" required pattern="(?:https?:\/\/)?(?:www\.)?github\.com\/([^\/]+\/[^\/]+?(?:\/tree\/[^\/]+)?)(?:\.git)?$" title="github.com/<user>/<repo> or
 github.com/<user>/<repo>/tree/<branch>"></label>
     <button type="submit">Serve!</button>
     <div id="error" style="display: none"></div>


### PR DESCRIPTION
If you paste in a git clone URL like this:

https://github.com/remy/5minutefork.git

It's accepted, but sends you down an infinite loop, cloning a repo that doesn't exist.

I changed the validation regexp to trim off the .git suffix if it exists using non-greedy matching. It also validates the pathname syntax (foo/bar or foo/bar/tree/baz).
