### PR TITLE
Use a github token instead of basic auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 forks/*
-credentials.json
+.env
 node_modules

--- a/README.md
+++ b/README.md
@@ -12,19 +12,17 @@ The code is pretty gnarly, but don't judge me - I wanted quick and dirty.
 
 ## Running
 
-The project requires github auth details to place API requests. Currently this is in the form of simple auth (which is a bit rubbish, and I'll take a PR to fix this!).
+The project requires a github OAuth token to place API requests. If you are not sure how to generate an OAuth token [Github have an article to help](https://help.github.com/articles/creating-an-access-token-for-command-line-use/)
 
 To run:
 
-    NODE_USER=githubUsername NODE_PASS=githubPassword node index.js
+    GITHUB_TOKEN=token node index.js
 
-Alternatively, you can put these credentials in a JSON config file in the root called `credentials.json`:
+Alternatively, you can put the token in a file in the root of this project called `.env`:
 
-```json
-{
-  "user": "githubUsername",
-  "pass": "githubPassword"
-}
+```BASH
+GITHUB_TOKEN=token
+NODE_DEBUG=true #Set to false for production
 ```
 
 `.gitignore` should ensure the file isn't sent up to github.

--- a/index.js
+++ b/index.js
@@ -106,8 +106,10 @@ var app = connect().use(connect.logger('dev')).use(connect.favicon(__dirname + '
           });
         } else {
           request('https://api.github.com/repos/' + fork.urlWithoutBranch.join('/'), {
-            'auth': credentials,
-            'headers': { 'user-agent': '5minfork - http://5minfork.com' }
+            'headers': {
+              'user-agent': '5minfork - http://5minfork.com',
+              'Authorization': 'token ' + credentials.githubToken
+            }
           }, function (e, r, body) {
             fork.gitdata = JSON.parse(body);
             fork.repo = fork.gitdata.git_url;

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -1,14 +1,11 @@
 'use strict';
-var fs = require('fs');
+require('dotenv').load();
 
-if (fs.existsSync(__dirname + '/../credentials.json')) {
-  module.exports = require(__dirname + '/../credentials.json');
-} else if (process.env.NODE_USER && process.env.NODE_PASS) {
+if (process.env.GITHUB_TOKEN) {
   module.exports = {
-    user: process.env.NODE_USER,
-    pass: process.env.NODE_PASS
+    githubToken: process.env.GITHUB_TOKEN
   };
 } else {
-  console.error('Credentials required to run 5minfork.\nDetails >> https://github.com/remy/5minutefork#running\n');
+  console.error('A token is required to run 5minfork.\nDetails >> https://github.com/remy/5minutefork#running\n');
   process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   "license": "MIT / http://rem.mit-license.org",
   "dependencies": {
     "connect": "~2.7.3",
-    "remove": "~0.1.5",
+    "dotenv": "^1.2.0",
     "mustache": "~0.7.2",
+    "remove": "~0.1.5",
     "request": "~2.16.6"
   }
 }


### PR DESCRIPTION
## Problem
Previously 5minutefork would use basic auth to authenticate with Github, which isn't ideal.

## Solution
Moved to using OAuth tokens for authentication.

## Changes
Environment variables `NODE_USER` & `NODE_PASS` were removed and replaced with `GITHUB_TOKEN`.
`credentials.json` was replaced with a `.env` file, this is loaded by the [dotenv module](https://www.npmjs.com/package/dotenv).
`README.md` was updated to reflect these configuration changes.